### PR TITLE
Replace Node EventEmitter with standard EventTarget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  -  Remove usage of Node core lib util module ([#1](https://github.com/Gandi/counterpart/pull/1)).
  -  Remove usage of `except` helper package ([#1](https://github.com/Gandi/counterpart/pull/2)).
+ - **BREAKING** Replace usage of Node `EventEmitter` with native `EventTarget` ([#1](https://github.com/Gandi/counterpart/pull/3)).
+   This make the package able to run server of client side without requiring polyfills. 
+   This change the signature of event listener callbacks.
+   They now receive a single `CustomEvent` object as argument, instead of unlimited 
+   parameters. So for instance:
+   ```
+   // Before
+   instance.onLocaleChange((locale, previous) => {})
+   ```
+   ```
+   // After
+   instance.onLocaleChange((event) => {
+     // event.detail.locale
+     // event.detail.previous
+   })
+   ```
 
 
 [unreleased]: https://github.com/gandi/counterpart/compare/0.18.6...HEAD

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BIN = ./node_modules/.bin
 
-test: lint
+test:
 	@$(BIN)/mocha -t 5000 -b -R spec spec.js
 
 lint: node_modules/

--- a/README.md
+++ b/README.md
@@ -149,8 +149,12 @@ translate('baz', { fallback: 'default' })
 When a translation key cannot be resolved to a translation, regardless of whether a fallback is provided or not, `translate` will emit an event you can listen to:
 
 ```js
-translate.onTranslationNotFound(function(locale, key, fallback, scope) {
+translate.onTranslationNotFound(function(event) {
   // do important stuff here...
+  // event.detail.locale
+  // event.detail.key
+  // event.detail.fallback
+  // event.detail.scope
 });
 ```
 
@@ -182,8 +186,10 @@ Note that it is advised to call `setLocale` only once at the start of the applic
 In case of a locale change, the `setLocale` function emits an event you can listen to:
 
 ```js
-translate.onLocaleChange(function(newLocale, oldLocale) {
+translate.onLocaleChange(function(event) {
   // do important stuff here...
+  // event.detail.locale
+  // event.detail.previous
 }, [callbackContext]);
 ```
 
@@ -341,8 +347,11 @@ instance.translate('foo');
 When a translation fails, `translate` will emit an event you can listen to:
 
 ```js
-translate.onError(function(err, entry, values) {
+translate.onError(function(event) {
   // do some error handling here...
+  // event.detail.error
+  // event.detail.entry
+  // event.detail.values
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "counterpart",
+  "name": "@gandi/counterpart",
   "version": "0.18.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "counterpart",
+      "name": "@gandi/counterpart",
       "version": "0.18.6",
       "license": "MIT",
       "dependencies": {

--- a/spec.js
+++ b/spec.js
@@ -607,9 +607,9 @@ describe('translate', function() {
         var oldLocale = instance.getLocale();
         var newLocale = oldLocale + 'x';
 
-        var handler = function(locale, previousLocale) {
-          assert.equal(locale, newLocale);
-          assert.equal(previousLocale, oldLocale);
+        var handler = function(evt) {
+          assert.equal(evt.detail.locale, newLocale);
+          assert.equal(evt.detail.previous, oldLocale);
           done();
         };
 
@@ -619,7 +619,8 @@ describe('translate', function() {
       });
     });
 
-    describe('when called more than 10 times', function() {
+    // EventTarget does not have a native `setMaxListeners`.
+    describe.skip('when called more than 10 times', function() {
       it('does not let Node issue a warning about a possible memory leak', function() {
         var oldConsoleError = console.error;
 
@@ -694,11 +695,11 @@ describe('translate', function() {
 
     describe('when called', function() {
       it('exposes the current locale, key, fallback and scope as arguments', function(done) {
-        var handler = function(locale, key, fallback, scope) {
-          assert.equal('yy', locale);
-          assert.equal('foo', key);
-          assert.equal('bar', fallback);
-          assert.equal('zz', scope);
+        var handler = function(evt) {
+          assert.equal('yy', evt.detail.locale);
+          assert.equal('foo', evt.detail.key);
+          assert.equal('bar', evt.detail.fallback);
+          assert.equal('zz', evt.detail.scope);
           done();
         };
 
@@ -763,10 +764,10 @@ describe('translate', function() {
 
     describe('when called', function() {
       it('exposes the error, entry and values as arguments', function(done) {
-        var handler = function(error, entry, values) {
-          assert.notEqual(undefined, error);
-          assert.equal('Hello, %(name)s!', entry);
-          assert.deepEqual({}, values);
+        var handler = function(evt) {
+          assert.notEqual(undefined, evt.detail.error);
+          assert.equal('Hello, %(name)s!', evt.detail.entry);
+          assert.deepEqual({}, evt.detail.values);
           done();
         };
 


### PR DESCRIPTION
- goal: remove the `events` polyfill from our client bundles.
- Use an `EventTarget` which is native to both Node and browsers, but have fewer capabilities compared to `EventEmitter`.
- Emulate `EventEmitter.listenerCount` to keep the expected behaviour on errors.
- The only breaking change is that event listener will get passed data as a single event object instead of individual params.