### PR TITLE
Add an engines constraint on Node >= 22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+  - Add `engines` key to package.json to forbid Node.js versions prior to `22.1.0`.
+    We now rely on `CustomEvent` which was made stable and available from that version.
 
 ## [1.1.0] - 2024-09-09
 ### Added

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "test": "mocha -t 5000 -b -R spec spec.js",
     "prepublishOnly": "npm test"
   },
+  "engines": {
+    "node": ">=22.1.0"
+  },
   "packageManager": "npm@10.8.3+sha512.d08425c8062f56d43bb8e84315864218af2492eb769e1f1ca40740f44e85bd148969382d651660363942e5909cb7ffcbef7ca0ae963ddc2c57a51243b4da8f56",
   "dependencies": {
     "date-names": "^0.1.11",


### PR DESCRIPTION
Add `engines` key to package.json to forbid Node.js versions prior to `22.1.0`.   
We now rely on `CustomEvent` which was made stable and available from that version.    
Prior to that it was only available under a flag.    

See https://nodejs.org/api/events.html#class-customevent   